### PR TITLE
Remap db

### DIFF
--- a/src/includes/pir.h
+++ b/src/includes/pir.h
@@ -93,8 +93,5 @@ private:
 
 // ================== HELPER FUNCTIONS ==================
 
-void print_entry(Entry entry);
-
-
 // Given a key_id and the hashed_key_width, generate a random key using random number generator.
 std::vector<uint8_t> gen_single_key(uint64_t key_id, size_t hashed_key_width);

--- a/src/includes/server.h
+++ b/src/includes/server.h
@@ -5,36 +5,34 @@
 #include "pir.h"
 #include <optional>
 
-typedef std::vector<std::optional<seal::Plaintext>> Database;
+typedef std::vector<std::optional<seal::Plaintext>> DatabaseChunk;  // 256 plaintexts
+typedef std::vector<DatabaseChunk> Database;
 typedef std::pair<uint64_t, uint64_t> CuckooSeeds;
-
-// struct for storing server public data after generating the database
-struct CuckooInitData {
-  std::vector<CuckooSeeds> used_seeds;  // all seeds used for constructing the cuckoo hash table
-  std::vector<Entry> inserted_data; // database containing all inserted entries
-};
 
 class PirServer {
 public:
   PirServer(const PirParams &pir_params);
 
   /**
-   * @brief Generate random data for the server database. Return the generated data for testing purposes.
+   * @brief Generate random data for the server database.
    */
-  std::vector<Entry> gen_data();
+  void gen_data();
 
   /**
    * @brief Generate random key-value pairs, configured using hashed_key_width_. 
    * Then set the database by inserting the key-value pairs using cuckoo hashing.
    * @return a copy of the generated database and all used seeds. The last pair of CuckooSeeds is the seeds used for the cuckoo hash.
    */
-  CuckooInitData gen_keyword_data(size_t max_iter, uint64_t keyword_seed);
+  std::vector<CuckooSeeds> gen_keyword_data(size_t max_iter, uint64_t keyword_seed);
 
   /**
    * @brief Sets the server database using the provided vector of entries
    * @param new_db 
    */
   void set_database(std::vector<Entry> &new_db);
+
+  // push one chunk of entry to the database
+  void push_database_chunk(std::vector<Entry> &chunk_entry);
 
   std::vector<uint64_t> get_dims() const;
 
@@ -59,6 +57,13 @@ public:
   void set_client_galois_key(const uint32_t client_id, std::stringstream &gsw_stream);
   void set_client_gsw_key(const uint32_t client_id, std::stringstream &gsw_stream);
 
+  /**
+  Asking the server to return the plaintext at the given (abstract) index.
+  This is not doing PIR. So this reveals the index to the server. This is
+  only for testing purposes.
+  */
+  seal::Plaintext direct_get_pt(const uint64_t index);
+
   seal::Decryptor *decryptor_;
 
   friend class PirTest;
@@ -71,6 +76,7 @@ private:
   std::map<uint32_t, seal::GaloisKeys> client_galois_keys_;
   std::map<uint32_t, GSWCiphertext> client_gsw_keys_;
   Database db_;
+  Database ntt_db_;
   PirParams pir_params_;
   size_t hashed_key_width_;
 

--- a/src/includes/server.h
+++ b/src/includes/server.h
@@ -101,7 +101,7 @@ private:
 * @param len length(size) of the entry. Each entry is a vector of bytes.
 * @return Entry 
 */
-Entry generate_entry(int id, size_t entry_size);
+Entry generate_entry(const uint64_t id, const size_t entry_size);
 
 /**
  * @brief Generate an entry with a key_id. This will be used as a seed for
@@ -111,7 +111,7 @@ Entry generate_entry(int id, size_t entry_size);
  * entry_size - hashed_key_width = value_size is the only limit for the generated value.
  * @return Entry
  */
-Entry generate_entry_with_id(uint64_t key_id, size_t entry_size, size_t hashed_key_width);
+Entry generate_entry_with_key(uint64_t key_id, size_t entry_size, size_t hashed_key_width);
 
 
 /**

--- a/src/includes/server.h
+++ b/src/includes/server.h
@@ -5,7 +5,8 @@
 #include "pir.h"
 #include <optional>
 
-typedef std::vector<std::optional<seal::Plaintext>> DatabaseChunk;  // 256 plaintexts
+// typedef std::vector<std::optional<seal::Plaintext>> DatabaseChunk;  // 256 plaintexts
+typedef std::unique_ptr<std::optional<seal::Plaintext>[]> DatabaseChunk;  // Heap allocation for N_1 plaintexts
 typedef std::vector<DatabaseChunk> Database;
 typedef std::pair<uint64_t, uint64_t> CuckooSeeds;
 

--- a/src/includes/utils.h
+++ b/src/includes/utils.h
@@ -127,4 +127,6 @@ bool entry_is_equal(const Entry &entry1, const Entry &entry2);
 
 // logical entry index to the actuall index in the database.
 // This is a trick we do for reducing the miss cache rate when evaluating the first dimension.
-size_t entry_idx_to_actual(const size_t entry_idx, const size_t fst_dim_sz, const size_t num_entries);
+size_t entry_idx_to_actual(const size_t entry_idx, const size_t fst_dim_sz, const size_t db_sz);
+
+void print_progress(size_t current, size_t total);

--- a/src/includes/utils.h
+++ b/src/includes/utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "pir.h"
 #include "seal/seal.h"
 #include <iostream>
 
@@ -113,3 +114,17 @@ gsw_gadget(size_t l, uint64_t base_log2, size_t coeff_mod_count,
 
 // Generate a prime that is bit_width long
 std::uint64_t generate_prime(size_t bit_width);
+
+void idxToEntry(const uint64_t idx, Entry &entry);
+
+// Given the entry, check if the first 8 bytes has the correct index
+bool check_entry_idx(const Entry &entry, const uint64_t query_idx);
+
+void print_entry(const Entry &entry);
+
+bool entry_is_equal(const Entry &entry1, const Entry &entry2);
+
+
+// logical entry index to the actuall index in the database.
+// This is a trick we do for reducing the miss cache rate when evaluating the first dimension.
+size_t entry_idx_to_actual(const size_t entry_idx, const size_t fst_dim_sz, const size_t num_entries);

--- a/src/pir.cpp
+++ b/src/pir.cpp
@@ -121,17 +121,7 @@ float PirParams::get_blowup_factor() const { return blowup_factor_; }
 
 // ================== HELPER FUNCTIONS ==================
 
-void print_entry(Entry entry) {
-  int cnt = 0;
-  for (auto &val : entry) {
-    std::cout << (int)val << ", ";
-    cnt += 1;
-    if (cnt > 10) {
-      break;
-    }
-  }
-  std::cout << std::endl;
-}
+
 
 
 Entry gen_single_key(uint64_t key_id, size_t hashed_key_width) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -160,15 +160,16 @@ PirServer::evaluate_first_dim(std::vector<seal::Ciphertext> &selection_vector) {
   // other_dim_sz many consecutive entries in the database. We are going to
   // multiply the selection_vector with the DB. Then only one row of the result
   // is going to be added to the result vector.
-  for (size_t row = 0; row < other_dim_sz; ++row) {
+  for (size_t j = 0; j < other_dim_sz; ++j) {
     std::vector<std::vector<uint128_t>> buffer(
         encrypted_ntt_size, std::vector<uint128_t>(coeff_val_cnt, 0));
-    // summing C_{BFV_k} * DB_{k(N / N_1) + j}
-    for (size_t col = 0; col < fst_dim_sz; col++) {
+    // // summing C_{BFV_k} * DB_{k(N / N_1) + j}
+    // summing C_{BFV_k} * DB_{N_1 * j + k}
+    for (size_t k = 0; k < fst_dim_sz; k++) {
       for (size_t poly_id = 0; poly_id < encrypted_ntt_size; poly_id++) {
-        if (db_[row + col * other_dim_sz].has_value()) { // if the entry is not empty
-          utils::multiply_poly_acum(selection_vector[col].data(poly_id),
-                                    (*db_[row + col * other_dim_sz]).data(),
+        if (db_[fst_dim_sz * j + k].has_value()) { // if the entry is not empty
+          utils::multiply_poly_acum(selection_vector[k].data(poly_id),
+                                    (*db_[fst_dim_sz * j + k]).data(),
                                     coeff_val_cnt, buffer[poly_id].data()); 
         }
       }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -9,15 +9,15 @@
 #include <random>
 
 // "Default" Parameters for the PIR scheme
-#define DB_SZ             1 << 10       // Database size <==> Number of plaintexts in the database
-#define NUM_ENTRIES       1 << 10       // Number of entries in the database, can be less than DB_SZ
+#define DB_SZ             1 << 17       // Database size <==> Number of plaintexts in the database
+#define NUM_ENTRIES       1 << 17       // Number of entries in the database, can be less than DB_SZ
 #define GSW_L             5             // Parameter for GSW scheme. 
 #define GSW_L_KEY         15            // GSW for query expansion
 #define FST_DIM_SZ        256           // Number of dimensions of the hypercube
 #define PT_MOD_WIDTH      48            // Width of the plain modulus 
 #define CT_MODS	         {60, 60, 60}  // Coeff modulus for the BFV scheme
 
-#define EXPERIMENT_ITERATIONS 1
+#define EXPERIMENT_ITERATIONS 10
 
 void print_func_name(std::string func_name) {
 #ifdef _DEBUG
@@ -334,7 +334,7 @@ void test_pir() {
 
     // ============= CLIENT ===============
     auto c_start_time = CURR_TIME;  // client start time for the query
-    PirQuery query = client.generate_query(actual_idx);
+    PirQuery query = client.generate_query(entry_index);
     auto query_size = client.write_query_to_stream(query, data_stream);
     
     // ============= SERVER ===============
@@ -344,7 +344,7 @@ void test_pir() {
     
     // client gets result from the server and decrypts it
     auto decrypted_result = client.decrypt_result(result);
-    Entry entry = client.get_entry_from_plaintext(actual_idx, decrypted_result[0]);
+    Entry entry = client.get_entry_from_plaintext(entry_index, decrypted_result[0]);
     auto c_end_time = CURR_TIME;
 
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -9,8 +9,8 @@
 #include <random>
 
 // "Default" Parameters for the PIR scheme
-#define DB_SZ             1 << 17       // Database size <==> Number of plaintexts in the database
-#define NUM_ENTRIES       1 << 17       // Number of entries in the database, can be less than DB_SZ
+#define DB_SZ             1 << 15       // Database size <==> Number of plaintexts in the database
+#define NUM_ENTRIES       1 << 15       // Number of entries in the database, can be less than DB_SZ
 #define GSW_L             5             // Parameter for GSW scheme. 
 #define GSW_L_KEY         15            // GSW for query expansion
 #define FST_DIM_SZ        256           // Number of dimensions of the hypercube
@@ -39,7 +39,6 @@ void run_tests() {
   // serialization_example();
 
   test_pir();
-  // find_pt_mod_width();
   // find_best_params();
   // test_cuckoo_keyword_pir(); // single server version
 
@@ -300,7 +299,7 @@ void test_pir() {
 
   BENCH_PRINT("Initializing server...");
   // Data to be stored in the database.
-  std::vector<Entry> data = server.gen_data();
+  server.gen_data();
   BENCH_PRINT("Server initialized");
 
   // Run the query process many times.
@@ -325,12 +324,11 @@ void test_pir() {
 
     // ===================== ONLINE PHASE =====================
     // Client start generating query
-    size_t entry_index = rand() % pir_params.get_num_entries();
-    auto actual_idx = entry_idx_to_actual(entry_index, FST_DIM_SZ, NUM_ENTRIES);
+    // size_t entry_index = rand() % pir_params.get_num_entries();
+    size_t entry_index = 25;
     BENCH_PRINT("Experiment [" << i << "]");
     DEBUG_PRINT("\t\tClient ID:\t" << client_id);
     DEBUG_PRINT("\t\tEntry index:\t" << entry_index);
-    DEBUG_PRINT("\t\tActual index:\t" << actual_idx);
 
     // ============= CLIENT ===============
     auto c_start_time = CURR_TIME;  // client start time for the query
@@ -348,6 +346,10 @@ void test_pir() {
     auto c_end_time = CURR_TIME;
 
 
+    // Directly get the plaintext from server. Not part of PIR.
+    Entry actual_data = client.get_entry_from_plaintext(
+        entry_index, server.direct_get_pt(entry_index));
+
     // ============= PRINTING RESULTS ===============
     DEBUG_PRINT("\t\tGalois size:\t" << galois_key_size);
     DEBUG_PRINT("\t\tGSW key size:\t" << gsw_key_size);
@@ -358,17 +360,17 @@ void test_pir() {
 
     server_time_sum += TIME_DIFF(s_start_time, s_end_time);
     client_time_sum += TIME_DIFF(c_start_time, c_end_time) - TIME_DIFF(s_start_time, s_end_time);
-    if (check_entry_idx(data[actual_idx], entry_index) && entry_is_equal(entry, data[actual_idx])) {
+    if (check_entry_idx(actual_data, entry_index) && entry_is_equal(entry, actual_data)) {
       // print a green success message
       std::cout << "\033[1;32mSuccess!\033[0m" << std::endl;
     } else {
       // print a red failure message
       std::cout << "\033[1;31mFailure!\033[0m" << std::endl;
 
-      std::cout << "Result:\t";
+      std::cout << "PIR Result:\t";
       print_entry(entry);
-      std::cout << "Data:\t";
-      print_entry(data[actual_idx]);
+      std::cout << "Actual Data:\t";
+      print_entry(actual_data);
     }
     PRINT_BAR;
   }
@@ -377,259 +379,99 @@ void test_pir() {
   std::cout << "Average client time: " << client_time_sum / EXPERIMENT_ITERATIONS << " ms" << std::endl;
 }
 
-void test_cuckoo_keyword_pir() {
-  print_func_name(__FUNCTION__);
-  const int experiment_times = 1;
 
-  const float blowup_factor = 2.0;
-  const size_t hashed_key_width = 16;
-  const size_t DBSize_ = 1 << 16;
-  const size_t num_entries = 1 << 16;
-  PirParams pir_params(DBSize_, FST_DIM_SZ, num_entries, GSW_L, GSW_L_KEY, PT_MOD_WIDTH, CT_MODS, hashed_key_width, blowup_factor);
-  pir_params.print_values();
-  PirServer server(pir_params);
+// void find_best_params() {
+//   print_func_name(__FUNCTION__);
 
-  DEBUG_PRINT("Initializing server...");
-  uint64_t keyword_seed = 123123;
-  CuckooInitData keyword_data = server.gen_keyword_data(100, keyword_seed);
+//   // open a file to write the results
+//   std::ofstream file;
+//   file.open("../outputs/best_param.txt");
+//   file << "l, l_key, server_time, all_success" << std::endl;
 
-  if (keyword_data.inserted_data.size() == 0) {
-    DEBUG_PRINT("Failed to insert data into cuckoo table. Exiting...");
-    return;
-  }
-  // Now we do have a cuckoo table with data inserted.
-  CuckooSeeds last_seeds = keyword_data.used_seeds.back();
-  uint64_t seed1 = last_seeds.first;
-  uint64_t seed2 = last_seeds.second;
-  DEBUG_PRINT("Seed1: " << seed1 << " Seed2: " << seed2);
-  
-  DEBUG_PRINT("Initializing client...");
-  PirClient client(pir_params);
-  for (int i = 0; i < experiment_times; i++) {
-    srand(time(0));
-    const int client_id = rand();
-    DEBUG_PRINT("Client ID: " << client_id);
+//   for (size_t curr_l_key = 13; curr_l_key < 20; ++curr_l_key) {
+//     for (size_t curr_l = 7; curr_l < 13; ++curr_l) {
+//       // setting parameters for PIR scheme
+//       PirParams pir_params(DB_SZ, FST_DIM_SZ, NUM_ENTRIES, curr_l, curr_l_key,
+//                             PT_MOD_WIDTH, CT_MODS);
+//       pir_params.print_values();
+//       PirServer server(pir_params);
 
-    // Initialize the client
-    PirClient client(pir_params);
-    std::stringstream galois_key_stream, gsw_stream, data_stream;
+//       DEBUG_PRINT("Initializing server...");
+//       // Data to be stored in the database.
+//       std::vector<Entry> data = server.gen_data();
+//       DEBUG_PRINT("Server initialized");
 
-    // Client create galois keys and gsw keys and writes to the stream (to the server)
-    size_t galois_key_size = client.create_galois_keys(galois_key_stream);
-    size_t gsw_key_size = client.write_gsw_to_stream(
-        client.generate_gsw_from_key(), gsw_stream);
-    //--------------------------------------------------------------------------------
-    server.decryptor_ = client.get_decryptor();
-    // Server receives the gsw keys and galois keys and loads them when needed
-    server.set_client_galois_key(client_id, galois_key_stream);
-    server.set_client_gsw_key(client_id, gsw_stream);
-
-    // Generate a random keyword using keyword_seed. 
-    size_t wanted_keyword_idx = rand() % num_entries;
-    std::mt19937_64 rng(keyword_seed);
-    rng.discard(wanted_keyword_idx);
-    Key wanted_keyword = rng();
-    DEBUG_PRINT("Wanted keyword: " << wanted_keyword);
-
-    // client start generating keyword query
-    auto c_start_time = CURR_TIME;
-    std::vector<PirQuery> queries = client.generate_cuckoo_query(seed1, seed2, num_entries, wanted_keyword);
-    auto c_end_time = CURR_TIME;
-
-    // server start processing the query
-    auto s_start_time = CURR_TIME;
-    // we know that there is only two queries in the vector queries.
-    auto reply1 = server.make_query(client_id, std::move(queries[0]));
-    auto reply2 = server.make_query(client_id, std::move(queries[1]));
-    auto s_end_time = CURR_TIME;
-
-    // client start processing the reply
-    auto c2_start_time = CURR_TIME;
-    client.cuckoo_process_reply(seed1, seed2, num_entries, wanted_keyword, reply1, reply2);
-    auto c2_end_time = CURR_TIME;
-
-    DEBUG_PRINT("Server Time: " << TIME_DIFF(s_start_time, s_end_time) << " ms");
-    DEBUG_PRINT("Client Time: " << TIME_DIFF(c_start_time, c_end_time) + TIME_DIFF(c2_start_time, c2_end_time) << " ms");
-    DEBUG_PRINT("Noise budget left: " << client.get_decryptor()->invariant_noise_budget(reply1[0]));
-    DEBUG_PRINT("Noise budget left: " << client.get_decryptor()->invariant_noise_budget(reply2[0]));
-
-  }
-
-
-}
-
-
-
-void find_pt_mod_width() {
-  print_func_name(__FUNCTION__);
-
-  // open a file to write the results
-  std::ofstream file;
-  file.open("../outputs/best_pt_mod.txt");
-  file << "pt_mod_width, server_time, success_rate" << std::endl;
-
-  for (size_t bit_width = 40; bit_width < 61; ++bit_width) {
-    // setting parameters for PIR scheme
-    PirParams pir_params(DB_SZ, FST_DIM_SZ, NUM_ENTRIES, GSW_L, GSW_L_KEY, bit_width, CT_MODS);
-    pir_params.print_values();
-    PirServer server(pir_params); // Setup server params
-
-    std::cout << "Initializing server..." << std::endl;
-    // Radomly generate data to be stored in the database.
-    std::vector<Entry> data = server.gen_data();
-
-    auto server_time_sum = 0;
-    size_t success_cnt = 0;
-    // Run the query process many times.
-    for (int i = 0; i < EXPERIMENT_ITERATIONS; i++) {
-      srand(time(0)); // reset the seed for the random number generator
-      // Initialize the client
-      PirClient client(pir_params);
-      const int client_id = rand();
-      std::stringstream galois_key_stream, gsw_stream, data_stream;
-
-      // Client create galois keys and gsw keys and writes to the stream (to the server)
-      size_t galois_key_size = client.create_galois_keys(galois_key_stream);
-      size_t gsw_key_size = client.write_gsw_to_stream(
-          client.generate_gsw_from_key(), gsw_stream);
-      //--------------------------------------------------------------------------------
-      server.decryptor_ = client.get_decryptor();
-      // Server receives the gsw keys and galois keys and loads them when needed
-      server.set_client_galois_key(client_id, galois_key_stream);
-      server.set_client_gsw_key(client_id, gsw_stream);
-
-      // === Client start generating query ===
-      size_t entry_index = rand() % pir_params.get_num_entries();
-      auto query = client.generate_query(entry_index);
-
-      auto s_start_time =
-          CURR_TIME; // server start time for processing the query
-      auto result = server.make_query(client_id, std::move(query));
-      auto s_end_time = CURR_TIME;
-
-      // client gets result from the server and decrypts it
-      auto decrypted_result = client.decrypt_result(result);
-      Entry entry =
-          client.get_entry_from_plaintext(entry_index, decrypted_result[0]);
-
-      // ================== Record the results ==================
-      std::cout << "Experiment [" << i
-                << "]\tServer time: " << TIME_DIFF(s_start_time, s_end_time)
-                << " ms" << std::endl;
-      server_time_sum += TIME_DIFF(s_start_time, s_end_time);
-
-      if (entry == data[entry_index]) {
-        // print a green success message
-        std::cout << "\033[1;32mSuccess!\033[0m" << std::endl;
-        success_cnt++;
-      } else {
-        // print a red failure message
-        std::cout << "\033[1;31mFailure!\033[0m" << std::endl;
-        break;
-      }
-    }
-    
-    // record the data
-    // bit_width, mod, success_rate, average server time
-    file << bit_width << " " << server_time_sum / EXPERIMENT_ITERATIONS << " "
-         << (double)success_cnt / (double)EXPERIMENT_ITERATIONS << std::endl;
-  }
-}
-
-
-
-void find_best_params() {
-  print_func_name(__FUNCTION__);
-
-  // open a file to write the results
-  std::ofstream file;
-  file.open("../outputs/best_param.txt");
-  file << "l, l_key, server_time, all_success" << std::endl;
-
-  for (size_t curr_l_key = 13; curr_l_key < 20; ++curr_l_key) {
-    for (size_t curr_l = 7; curr_l < 13; ++curr_l) {
-      // setting parameters for PIR scheme
-      PirParams pir_params(DB_SZ, FST_DIM_SZ, NUM_ENTRIES, curr_l, curr_l_key,
-                            PT_MOD_WIDTH, CT_MODS);
-      pir_params.print_values();
-      PirServer server(pir_params);
-
-      DEBUG_PRINT("Initializing server...");
-      // Data to be stored in the database.
-      std::vector<Entry> data = server.gen_data();
-      DEBUG_PRINT("Server initialized");
-
-      auto server_time_sum = 0;
-      bool all_success = true;
-      int end_iter = EXPERIMENT_ITERATIONS;
-      // Run the query process many times.
-      for (int i = 0; i < EXPERIMENT_ITERATIONS; i++) {
+//       auto server_time_sum = 0;
+//       bool all_success = true;
+//       int end_iter = EXPERIMENT_ITERATIONS;
+//       // Run the query process many times.
+//       for (int i = 0; i < EXPERIMENT_ITERATIONS; i++) {
         
-        // ============= OFFLINE PHASE ==============
-        // Initialize the client
-        PirClient client(pir_params);
-        const int client_id = rand();
-        std::stringstream galois_key_stream, gsw_stream, data_stream;
+//         // ============= OFFLINE PHASE ==============
+//         // Initialize the client
+//         PirClient client(pir_params);
+//         const int client_id = rand();
+//         std::stringstream galois_key_stream, gsw_stream, data_stream;
 
-        // Client create galois keys and gsw keys and writes to the stream (to the server)
-        size_t galois_key_size = client.create_galois_keys(galois_key_stream);
-        size_t gsw_key_size = client.write_gsw_to_stream(
-            client.generate_gsw_from_key(), gsw_stream);
-        //--------------------------------------------------------------------------------
-        server.decryptor_ = client.get_decryptor();
-        // Server receives the gsw keys and galois keys and loads them when needed
-        server.set_client_galois_key(client_id, galois_key_stream);
-        server.set_client_gsw_key(client_id, gsw_stream);
+//         // Client create galois keys and gsw keys and writes to the stream (to the server)
+//         size_t galois_key_size = client.create_galois_keys(galois_key_stream);
+//         size_t gsw_key_size = client.write_gsw_to_stream(
+//             client.generate_gsw_from_key(), gsw_stream);
+//         //--------------------------------------------------------------------------------
+//         server.decryptor_ = client.get_decryptor();
+//         // Server receives the gsw keys and galois keys and loads them when needed
+//         server.set_client_galois_key(client_id, galois_key_stream);
+//         server.set_client_gsw_key(client_id, gsw_stream);
 
-        // ===================== ONLINE PHASE =====================
-        // Client start generating query
-        size_t entry_index = rand() % pir_params.get_num_entries();
+//         // ===================== ONLINE PHASE =====================
+//         // Client start generating query
+//         size_t entry_index = rand() % pir_params.get_num_entries();
 
-        // ============= CLIENT ===============
-        PirQuery query = client.generate_query(entry_index);
-        auto query_size = client.write_query_to_stream(query, data_stream);
+//         // ============= CLIENT ===============
+//         PirQuery query = client.generate_query(entry_index);
+//         auto query_size = client.write_query_to_stream(query, data_stream);
         
-        // ============= SERVER ===============
-        auto s_start_time = CURR_TIME;  // server start time for processing the query
-        auto result = server.make_seeded_query(client_id, data_stream);
-        auto s_end_time = CURR_TIME;
+//         // ============= SERVER ===============
+//         auto s_start_time = CURR_TIME;  // server start time for processing the query
+//         auto result = server.make_seeded_query(client_id, data_stream);
+//         auto s_end_time = CURR_TIME;
         
-        // client gets result from the server and decrypts it
-        auto decrypted_result = client.decrypt_result(result);
-        Entry entry = client.get_entry_from_plaintext(entry_index, decrypted_result[0]);
+//         // client gets result from the server and decrypts it
+//         auto decrypted_result = client.decrypt_result(result);
+//         Entry entry = client.get_entry_from_plaintext(entry_index, decrypted_result[0]);
 
-        // ================== Record the results ==================
-        std::cout << "Experiment [" << i
-                  << "]\tServer time: " << TIME_DIFF(s_start_time, s_end_time)
-                  << " ms" << std::endl;
-        server_time_sum += TIME_DIFF(s_start_time, s_end_time);
+//         // ================== Record the results ==================
+//         std::cout << "Experiment [" << i
+//                   << "]\tServer time: " << TIME_DIFF(s_start_time, s_end_time)
+//                   << " ms" << std::endl;
+//         server_time_sum += TIME_DIFF(s_start_time, s_end_time);
 
-        if (entry == data[entry_index]) {
-          // print a green success message
-          std::cout << "\033[1;32mSuccess!\033[0m" << std::endl;
-        } else {
-          // print a red failure message
-          std::cout << "\033[1;31mFailure!\033[0m" << std::endl;
-          all_success = false;
-          end_iter = i + 1;
-          break;
-        }
-      }
+//         if (entry == data[entry_index]) {
+//           // print a green success message
+//           std::cout << "\033[1;32mSuccess!\033[0m" << std::endl;
+//         } else {
+//           // print a red failure message
+//           std::cout << "\033[1;31mFailure!\033[0m" << std::endl;
+//           all_success = false;
+//           end_iter = i + 1;
+//           break;
+//         }
+//       }
 
-      // record the data
-      file << curr_l << " " << curr_l_key << " "
-            << server_time_sum / end_iter << " "
-            << " " << all_success << std::endl;
+//       // record the data
+//       file << curr_l << " " << curr_l_key << " "
+//             << server_time_sum / end_iter << " "
+//             << " " << all_success << std::endl;
 
-      std::cout << "Average server time: " << server_time_sum / end_iter
-                << " ms" << std::endl;
-    }
-  }
+//       std::cout << "Average server time: " << server_time_sum / end_iter
+//                 << " ms" << std::endl;
+//     }
+//   }
 
-  // close the file
-  file.close();
+//   // close the file
+//   file.close();
 
-}
+// }
 
 void test_prime_gen() {
   print_func_name(__FUNCTION__);

--- a/src/two_tab_server.cpp
+++ b/src/two_tab_server.cpp
@@ -85,7 +85,7 @@ CuckooInitData PirServer::gen_keyword_data(size_t max_iter, uint64_t keyword_see
       for (size_t j = 0; j < pir_params_.get_num_entries(); ++j) {
         // Keyword(string) -> hash to fixed size bit string
         Key entry_key = keywords[j];
-        Entry entry = generate_entry_with_id(entry_key, entry_size, hashed_key_width);
+        Entry entry = generate_entry_with_key(entry_key, entry_size, hashed_key_width);
         size_t out1[4];
         MurmurHash3_x86_128(&entry_key, sizeof(entry_key), seed1, out1);
         size_t index1 = out1[0] % half_size;
@@ -434,7 +434,7 @@ Entry generate_entry(int id, size_t entry_size) {
 }
 
 
-Entry generate_entry_with_id(uint64_t key_id, size_t entry_size, size_t hashed_key_width) {
+Entry generate_entry_with_key(uint64_t key_id, size_t entry_size, size_t hashed_key_width) {
   if (entry_size < hashed_key_width) {
     throw std::invalid_argument("Entry size is too small for the hashed key width");
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -186,20 +186,28 @@ bool entry_is_equal(const Entry &entry1, const Entry &entry2) {
   return true;
 }
 
-size_t entry_idx_to_actual(const size_t entry_idx, const size_t fst_dim_sz, const size_t num_entries) {
-
+size_t entry_idx_to_actual(const size_t entry_idx, const size_t fst_dim_sz, const size_t db_sz) {
   // compute N / N_1
-  size_t other_dim_sz = num_entries / fst_dim_sz;
-
+  size_t other_dim_sz = db_sz / fst_dim_sz;
 
   // we remap (N/N_1) * k + j to k + j * N_1
   size_t k = entry_idx / other_dim_sz;
   size_t j = entry_idx % other_dim_sz;
-
-  DEBUG_PRINT("fst_dim_sz: " << fst_dim_sz);
-  DEBUG_PRINT("num_entries: " << num_entries);
-  DEBUG_PRINT("other_dim_sz: " << other_dim_sz);
-  DEBUG_PRINT("entry_idx: " << entry_idx << " k: " << k << " j: " << j);
-
   return k + j * fst_dim_sz;
+}
+
+void print_progress(size_t current, size_t total) {
+#ifdef _DEBUG
+  float progress = static_cast<float>(current) / total;
+  int bar_width = 70;
+  std::cout << "[";
+  int pos = static_cast<int>(bar_width * progress);
+  for (int i = 0; i < bar_width; ++i) {
+      if (i < pos) std::cout << "=";
+      else if (i == pos) std::cout << ">";
+      else std::cout << " ";
+  }
+  std::cout << "] " << int(progress * 100.0) << " %\r";
+  std::cout.flush();
+#endif
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -136,3 +136,70 @@ std::uint64_t generate_prime(size_t bit_width) {
   
   return candidate;
 }
+
+// converting a uint64_t to a std::vector<uint8_t> of size 8
+void idxToEntry(const uint64_t idx, Entry &entry) {
+  // Convert id to bytes and push them to the entry.
+  for (int i = 7; i >= 0; --i) {
+      // Shift the value to the right and mask the lowest byte, then push it to the vector
+      entry.push_back(static_cast<uint8_t>(idx >> (i * 8)));
+  }
+}
+
+bool check_entry_idx(const Entry &entry, const uint64_t query_idx) {
+  Entry query_entry;
+  idxToEntry(query_idx, query_entry);
+
+  bool flag = true;
+  // compare the first 8 bytes of the entry with the query_idx
+  for (int i = 0; i < query_entry.size(); i++) {
+    if (entry[i] != query_entry[i]) {
+      DEBUG_PRINT("entry[" << i << "] = " << (int)entry[i] << " query_entry[" << i << "] = " << (int)query_entry[i]);
+      flag = false;
+    }
+  }
+  return flag;
+}
+
+
+
+void print_entry(const Entry &entry) {
+  int cnt = 0;
+  for (auto &val : entry) {
+    if (cnt < 10) { 
+      std::cout << (int)val << ", ";
+    }
+    cnt += 1;
+  }
+  std::cout << std::endl;
+}
+
+
+bool entry_is_equal(const Entry &entry1, const Entry &entry2) {
+  for (size_t i = 0; i < entry1.size(); i++) {
+    if (entry1[i] != entry2[i]) {
+      std::cerr << "Entries are not equal" << std::endl;
+      return false;
+    }
+  }
+  std::cout << "Entries are equal" << std::endl;
+  return true;
+}
+
+size_t entry_idx_to_actual(const size_t entry_idx, const size_t fst_dim_sz, const size_t num_entries) {
+
+  // compute N / N_1
+  size_t other_dim_sz = num_entries / fst_dim_sz;
+
+
+  // we remap (N/N_1) * k + j to k + j * N_1
+  size_t k = entry_idx / other_dim_sz;
+  size_t j = entry_idx % other_dim_sz;
+
+  DEBUG_PRINT("fst_dim_sz: " << fst_dim_sz);
+  DEBUG_PRINT("num_entries: " << num_entries);
+  DEBUG_PRINT("other_dim_sz: " << other_dim_sz);
+  DEBUG_PRINT("entry_idx: " << entry_idx << " k: " << k << " j: " << j);
+
+  return k + j * fst_dim_sz;
+}


### PR DESCRIPTION
We remap the database from (N/N_1)*k + j to N_1*j + k. This allows us to evaluate the first dimension in a consecutive order, which should be more cache friendly. It also allow us to reshape the database to a (N/N_1)*N_1 size 2D vector. 